### PR TITLE
fix: trim whitespace from volume contents

### DIFF
--- a/src/play.rs
+++ b/src/play.rs
@@ -44,7 +44,7 @@ impl InitialProperties {
         // Basically just read from the volume file if it exists, otherwise return 100.
         let volume = if volume.exists() {
             let contents = fs::read_to_string(volume).await?;
-            let stripped = contents.strip_suffix("%").unwrap_or(&contents);
+            let stripped = contents.trim().strip_suffix("%").unwrap_or(&contents);
             stripped
                 .parse()
                 .map_err(|_| eyre!("volume.txt file is invalid"))?


### PR DESCRIPTION
Love the player and it's simplicity - thanks ❤️ 

This change set simply trims the volume contents from any leading and trailing whitespaces. I'm not trimming ending newlines in my editor ;)