### PR TITLE
fix: properly trim volume content before stripping percentage sign

### DIFF
--- a/src/play.rs
+++ b/src/play.rs
@@ -44,7 +44,8 @@ impl InitialProperties {
         // Basically just read from the volume file if it exists, otherwise return 100.
         let volume = if volume.exists() {
             let contents = fs::read_to_string(volume).await?;
-            let stripped = contents.trim().strip_suffix("%").unwrap_or(&contents);
+            let trimmed = contents.trim();
+            let stripped = trimmed.strip_suffix("%").unwrap_or(&trimmed);
             stripped
                 .parse()
                 .map_err(|_| eyre!("volume.txt file is invalid"))?


### PR DESCRIPTION
This change set properly fixes the trimming of the volume file content before a potential percentage sign is stripped. Before this change and in the case if there is NO stripping happening the untrimmed content would be used which fails to parse to an int.