### PR TITLE
Add dynamic handling of play/pause state in bottom controls bar

### DIFF
--- a/src/player/ui.rs
+++ b/src/player/ui.rs
@@ -131,7 +131,7 @@ async fn interface(player: Arc<Player>, minimalist: bool) -> eyre::Result<()> {
             VOLUME_TIMER.store(0, Ordering::Relaxed);
         }
 
-        let controls = components::controls(WIDTH);
+        let controls = components::controls(&player, WIDTH);
 
         let menu = if minimalist {
             vec![action, middle]

--- a/src/player/ui/components.rs
+++ b/src/player/ui/components.rs
@@ -103,8 +103,9 @@ pub fn action(player: &Player, width: usize) -> String {
 }
 
 /// Creates the bottom controls bar, and also spaces it properly.
-pub fn controls(width: usize) -> String {
-    let controls = [["[s]", "kip"], ["[p]", "ause"], ["[q]", "uit"]];
+pub fn controls(player: &Player, width: usize) -> String {
+    let play_pause = if player.sink.is_paused() { ["[p]", "lay "] } else { ["[p]", "ause"] };
+    let controls = [["[s]", "kip"], play_pause, ["[q]", "uit"]];
     let len: usize = controls.concat().iter().map(|x| x.len()).sum();
     let controls = controls.map(|x| format!("{}{}", x[0].bold(), x[1]));
 


### PR DESCRIPTION
This is the implemenation of the issue described in #29.

Regarding the implementation:

1. There was no style guide on contributing to the project so I assumed there was an 80 character limit which is why I didn't just add the handling of the state inside the first `controls` variable's array.
2. I noticed the container sizing would have broken if I didn't add the single whitespace as padding to the `["[p]", "lay "]`. That doesn't look great and would like a more proper padding/whitespace calculation logic but didn't think it was worth consuming time for that when this version also works. I just don't like it.
3. Used the same arguments ordering in the function signature as with `components::action` and `components::progress_bar`: `&player` first, `width` second.

Here's how the controls looks in the terminal:

```sh
$ ./target/release/lowfi
┌─────────────────────────────┐
│ playing Feel The Same       │
│  [////       ] 00:50/02:03  │
│ [s]kip    [p]ause    [q]uit │
└─────────────────────────────┘

$ ./target/release/lowfi
┌─────────────────────────────┐
│ paused Feel The Same        │
│  [//////     ] 01:11/02:03  │
│ [s]kip    [p]lay     [q]uit │
└─────────────────────────────┘
```