### PR TITLE
feat: MPRIS, use underscore to split "lowfi" and list

### DIFF
--- a/src/player/mpris.rs
+++ b/src/player/mpris.rs
@@ -262,7 +262,7 @@ impl Server {
 
     /// Creates a new MPRIS server.
     pub async fn new(player: Arc<super::Player>, sender: Sender<Messages>) -> eyre::Result<Self> {
-        let suffix = format!("lowfi.{}.instance{}", player.list.name, process::id());
+        let suffix = format!("lowfi_{}.instance{}", player.list.name, process::id());
 
         let server = mpris_server::Server::new(&suffix, Player { player, sender }).await?;
 


### PR DESCRIPTION
Tiny change, didn't thought about it while discussing #40. I think it makes more sense to split required unique part "instance$PID" and list differently, will also make it easier to parse with scripts.

```sh
# lowfi_lofigirl.instance12345
playerctl --list-all | cut -d '.' -f 1  # human-friendly name
playerctl --list-all | cut -d '.' -f 2- # required unique id, unnecessary to be viewed by humans most of the time :)
```