### PR TITLE
Added the feature described in issue #44

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,10 @@ struct Args {
     #[clap(long, short)]
     debug: bool,
 
+    /// The width of the player
+    #[clap(long, short)]
+    width: Option<usize>,
+
     /// This is either a path, or a name of a file in the data directory (eg. ~/.local/share/lowfi).
     #[clap(long, short, alias = "list", short_alias = 'l')]
     tracks: Option<String>,

--- a/src/player/ui/components.rs
+++ b/src/player/ui/components.rs
@@ -116,5 +116,10 @@ pub fn controls(width: usize) -> String {
     let len: usize = controls.concat().iter().map(|x| x.len()).sum();
     let controls = controls.map(|x| format!("{}{}", x[0].bold(), x[1]));
 
-    controls.join(&" ".repeat((width - len) / (controls.len() - 1)))
+    let mut controls = controls.join(&" ".repeat((width - len) / (controls.len() - 1)));
+    controls.push_str(match width % 2 {
+        0 => " ",
+        _ => "",
+    });
+    controls
 }

--- a/src/player/ui/components.rs
+++ b/src/player/ui/components.rs
@@ -117,6 +117,8 @@ pub fn controls(width: usize) -> String {
     let controls = controls.map(|x| format!("{}{}", x[0].bold(), x[1]));
 
     let mut controls = controls.join(&" ".repeat((width - len) / (controls.len() - 1)));
+    // This is needed because changing the above line
+    // only works for when the width is even
     controls.push_str(match width % 2 {
         0 => " ",
         _ => "",


### PR DESCRIPTION
This allows users to specify the UI width with the `-w` flag.
It also limits the minimum width of the UI to 21, any smaller and the controls start overlapping.