### PR TITLE
fix: remove unsoundness with impl Send+Sync for OutputChannel

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -151,11 +151,19 @@ fn output_stream_manager(
     commands: std::sync::mpsc::Receiver<Infallible>,
 ) {
     // We should only shut up alsa forcefully if we really have to.
-    let maybe_stream = if cfg!(target_os = "linux") && create_silently {
-        silent_get_output_stream()
-    } else {
-        OutputStream::try_default().map_err(eyre::ErrReport::from)
-    };
+    let maybe_stream;
+    #[cfg(target_os = "linux")]
+    {
+        if create_silently {
+            maybe_stream = silent_get_output_stream();
+        } else {
+            maybe_stream = OutputStream::try_default().map_err(eyre::ErrReport::from);
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        maybe_stream = OutputStream::try_default().map_err(eyre::ErrReport::from);
+    }
 
     let (_stream, handle) = match maybe_stream {
         Ok(items) => items,

--- a/src/player.rs
+++ b/src/player.rs
@@ -108,6 +108,8 @@ pub struct Player {
     /// The [`OutputStreamHandle`], which also can control some
     /// playback, is for now unused and is here just to keep it
     /// alive so the playback can function properly.
+    /// The [`OutputStream`] associated with it has been leaked in the [`Player::new`] function,
+    /// so if the [`OutputStreamHandle`] is dropped, we will never get at the [`OutputStream`].
     _handle: OutputStreamHandle,
 }
 


### PR DESCRIPTION
Previously the code had this:

```rust
// SAFETY: This is necessary because [OutputStream] does not implement [Send],
// due to some limitation with Android's Audio API.
// I'm pretty sure nobody will use lowfi with android, so this is safe.
unsafe impl Send for Player {}

// SAFETY: See implementation for [Send].
unsafe impl Sync for Player {}
```

Now, there may not be a good reason why `OutputStream` (and particularly `cpal::Stream`) are not Send (see https://github.com/RustAudio/cpal/issues/793: they did this in anticipation of Android support which didn't exist at the time).
However, it still feels wrong to use `unsafe` for this, as we're essentially lying to the type system.

So, if there isn't anything preventing you from building it on Android, and it still has the thread limitation, then (with the Tokio multithread executor) it's going to be very easy to cause [mass hysteria and thread model errors](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/human-sacrifice-dogs-and-cats-living-together-mass-hysteria-and-thread-model-errors). 

I identified two solutions:

1. (simpler, but worse) Leak the `OutputChannel` at the point of creation. We don't need access to it as such, because all interaction can be done with the `OutputChannelHandle`. By leaking it, we make it live forever, which is probably acceptable (as we only ever intend to spawn a single `Player` per application instance), but it means that the on-Drop cleanup is now left up to the OS. This works fine on Linux and Windows, but it might be a problem on others. Regardless, leaking memory is a Safe Rust operation, so this should not cause soundness bugs on any platform if the underlying library is sound.
2. (more complicated, but better) Spawn a separate thread to hold the `OutputChannel` for us. We will talk to the thread with a `std::sync::mpsc::channel` (which is `Send`able, so it lives in the `Player`). When the `Player` is dropped, the channel is too, and that signals the thread to exit, which runs any Drop cleanup that may be needed.

Initially I implemented the first approach, but then I realized that the second approach works and is even safer (as the drop-time code is now guaranteed to run). 
Both approaches have been tested to work on `x86_64-unknown-linux-gnu` and  `x86_64-pc-windows-msvc`.

---

In addition, I made it so that the curious code you're using to temporarily swap out the `stderr` file stream is now only compiled in on Linux: it only makes sense to use it there, because it refers to the literal path of `/dev/null`. 
I'm not a big fan of that either, and I would look for a solution that doesn't use `unsafe` in your code. 
The two `freopen` calls are the only other place where `unsafe` is used, so if those were removed then you could make the entire project `#![forbid(unsafe_code)]`.