### PR TITLE
Fix debian typo in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ zypper install lowfi
 
 ```sh
 curl -sS https://debian.griffo.io/3B9335DF576D3D58059C6AA50B56A1A69762E9FF.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
-echo "deb https://debian.griffo.io//apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
 sudo apt install -y lowfi
 ```
 


### PR DESCRIPTION
This is a minor fix, packages are being downloaded without problems, but my webserver is showing this