### PR TITLE
docs: add repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ and as such it buffers 5 whole songs at a time instead of parts of the same song
 > If you're interested in maintaining a package for `lowfi`
 > on package managers such as homebrew and the like, open an issue.
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/lowfi.svg)](https://repology.org/project/lowfi/versions)
+
 ### Methods
 
 - [Cargo](#cargo)
@@ -72,8 +74,6 @@ Also see [Extra Features](#extra-features) for extended functionality.
 
 If you're struggling or unwilling to use cargo, you can just download the
 precompiled binaries from the [latest release](https://github.com/talwat/lowfi/releases/latest).
-
-[![Packaging status](https://repology.org/badge/vertical-allrepos/lowfi.svg)](https://repology.org/project/lowfi/versions)
 
 ### AUR
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Also see [Extra Features](#extra-features) for extended functionality.
 If you're struggling or unwilling to use cargo, you can just download the
 precompiled binaries from the [latest release](https://github.com/talwat/lowfi/releases/latest).
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/lowfi.svg)](https://repology.org/project/lowfi/versions)
+
 ### AUR
 
 ```sh


### PR DESCRIPTION
https://github.com/talwat/lowfi/blob/repology/README.md#release-binaries

<img width="309" height="161" alt="image" src="https://github.com/user-attachments/assets/1e5c0ae9-900f-44db-86b0-b2204662c2d4" />

thought it would be good to have since we have #25 open