### PR TITLE
Add Now Playing / media key support for Mac OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +435,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +503,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -480,6 +526,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
 
 [[package]]
 name = "coreaudio-rs"
@@ -522,7 +592,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -597,6 +667,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +727,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -813,6 +909,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1398,6 +1509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1573,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "core-foundation-sys",
  "crossterm",
  "dirs",
  "eyre",
@@ -1467,6 +1588,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "souvlaki",
  "thiserror 2.0.18",
  "tokio",
  "unicode-segmentation",
@@ -1484,6 +1606,15 @@ name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
@@ -1645,6 +1776,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2251,7 +2391,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2336,7 +2476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2503,6 +2643,24 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "souvlaki"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5855c8f31521af07d896b852eaa9eca974ddd3211fc2ae292e58dda8eb129bc8"
+dependencies = [
+ "base64",
+ "block",
+ "cocoa",
+ "core-graphics",
+ "dbus",
+ "dbus-crossroads",
+ "dispatch",
+ "objc",
+ "thiserror 1.0.69",
+ "windows 0.44.0",
 ]
 
 [[package]]
@@ -3298,6 +3456,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
@@ -3411,6 +3578,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ indicatif = { version = "0.18.4", optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.182"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+souvlaki = "0.8"
+core-foundation-sys = "0.8"
+
 [lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -200,6 +200,9 @@ impl Player {
 
             #[cfg(feature = "mpris")]
             self.ui.mpris.handle(&message).await?;
+
+            #[cfg(target_os = "macos")]
+            self.ui.macos.handle(&message).await?;
         }
 
         Ok(())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,9 @@ pub use interface::Interface;
 #[cfg(feature = "mpris")]
 pub mod mpris;
 
+#[cfg(target_os = "macos")]
+pub mod macos;
+
 /// Shorthand for a [`Result`] with a [`ui::Error`].
 type Result<T> = std::result::Result<T, Error>;
 
@@ -114,6 +117,10 @@ pub struct Handle {
     /// The MPRIS server, which is more or less a handle to the actual MPRIS thread.
     #[cfg(feature = "mpris")]
     pub mpris: mpris::Server,
+
+    /// The macOS Now Playing / media controls server.
+    #[cfg(target_os = "macos")]
+    pub macos: macos::Server,
 }
 
 impl Handle {

--- a/src/ui/init.rs
+++ b/src/ui/init.rs
@@ -12,6 +12,9 @@ impl crate::Tasks {
         #[cfg(feature = "mpris")]
         let mpris = ui::mpris::Server::new(state.clone(), self.tx(), urx.resubscribe()).await?;
 
+        #[cfg(target_os = "macos")]
+        let macos = ui::macos::Server::new(state.clone(), self.tx(), urx.resubscribe());
+
         let params = interface::Params::try_from(args)?;
         if params.enabled {
             self.spawn(ui::run(urx, state, params));
@@ -22,6 +25,8 @@ impl crate::Tasks {
             updater: utx,
             #[cfg(feature = "mpris")]
             mpris,
+            #[cfg(target_os = "macos")]
+            macos,
         })
     }
 }

--- a/src/ui/macos.rs
+++ b/src/ui/macos.rs
@@ -1,12 +1,6 @@
 //! Contains the code for macOS media controls via the Now Playing framework.
 
-use std::{
-    sync::{
-        mpsc::{self, SyncSender},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use core_foundation_sys::runloop::{kCFRunLoopDefaultMode, CFRunLoopRunInMode};
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
@@ -16,22 +10,7 @@ use crate::{player::Current, ui::Update, Message};
 
 use super::State;
 
-/// Internal update sent from the tokio runtime to the macOS media thread.
-enum MacosUpdate {
-    /// Update the Now Playing metadata with a new track title and duration.
-    Metadata {
-        /// The display name of the track.
-        title: String,
-        /// The duration of the track, if known.
-        duration: Option<Duration>,
-    },
-    /// Update the playback status (playing, paused, or stopped).
-    Playback(MediaPlayback),
-    /// Shut down the media controls thread.
-    Quit,
-}
-
-/// Handle to the macOS Now Playing / media controls background thread.
+/// Handle to the macOS Now Playing media controls.
 pub struct Server {
     /// Shared audio sink, used to read paused state.
     sink: Arc<rodio::Player>,
@@ -39,72 +18,41 @@ pub struct Server {
     /// The latest known track state.
     current: Current,
 
-    /// Channel to send updates to the background thread.
-    update_tx: SyncSender<MacosUpdate>,
+    /// The souvlaki media controls handle. `None` if initialisation failed.
+    controls: Option<MediaControls>,
 
     /// Broadcast receiver for track/state updates from the player.
     receiver: broadcast::Receiver<Update>,
 }
 
 impl Server {
-    /// Creates the macOS media controls server and spawns the background thread.
+    /// Creates the macOS media controls server.
     pub fn new(
         state: State,
         sender: tmpsc::Sender<Message>,
         receiver: broadcast::Receiver<Update>,
     ) -> Self {
-        let (update_tx, update_rx) = mpsc::sync_channel::<MacosUpdate>(8);
+        let config = PlatformConfig {
+            display_name: "lowfi",
+            dbus_name: "dev.talwat.lowfi",
+            hwnd: None,
+        };
 
-        std::thread::spawn(move || {
-            let config = PlatformConfig {
-                display_name: "lowfi",
-                dbus_name: "dev.talwat.lowfi",
-                hwnd: None,
-            };
-
-            let Ok(mut controls) = MediaControls::new(config) else {
-                return;
-            };
-
-            let _ = controls.attach(move |event: MediaControlEvent| {
-                let message = match event {
-                    MediaControlEvent::Play => Message::Play,
-                    MediaControlEvent::Pause => Message::Pause,
-                    MediaControlEvent::Toggle => Message::PlayPause,
-                    MediaControlEvent::Next => Message::Next,
-                    MediaControlEvent::Quit => Message::Quit,
-                    _ => return,
-                };
-                let _ = sender.try_send(message);
-            });
-
-            loop {
-                // Drain all pending updates from the tokio side without blocking.
-                loop {
-                    match update_rx.try_recv() {
-                        Ok(MacosUpdate::Metadata { title, duration }) => {
-                            let _ = controls.set_metadata(MediaMetadata {
-                                title: Some(title.as_str()),
-                                album: None,
-                                artist: None,
-                                cover_url: None,
-                                duration,
-                            });
-                        }
-                        Ok(MacosUpdate::Playback(status)) => {
-                            let _ = controls.set_playback(status);
-                        }
-                        Ok(MacosUpdate::Quit) | Err(mpsc::TryRecvError::Disconnected) => return,
-                        Err(mpsc::TryRecvError::Empty) => break,
-                    }
-                }
-
-                // Pump this thread's CFRunLoop briefly, in case souvlaki dispatches
-                // callbacks here rather than on the main queue.
-                unsafe {
-                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, 0);
-                }
-            }
+        let controls = MediaControls::new(config).ok().and_then(|mut controls| {
+            controls
+                .attach(move |event: MediaControlEvent| {
+                    let message = match event {
+                        MediaControlEvent::Play => Message::Play,
+                        MediaControlEvent::Pause => Message::Pause,
+                        MediaControlEvent::Toggle => Message::PlayPause,
+                        MediaControlEvent::Next => Message::Next,
+                        MediaControlEvent::Quit => Message::Quit,
+                        _ => return,
+                    };
+                    let _ = sender.try_send(message);
+                })
+                .ok()?;
+            Some(controls)
         });
 
         // Pump the main CFRunLoop on a ~60 Hz interval so that MPRemoteCommandCenter
@@ -114,6 +62,7 @@ impl Server {
         // queue needs to be drained.
         tokio::spawn(async {
             let mut interval = tokio::time::interval(Duration::from_millis(16));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
                 unsafe {
@@ -125,25 +74,36 @@ impl Server {
         Self {
             sink: state.sink,
             current: state.current,
-            update_tx,
+            controls,
             receiver,
         }
     }
 
     /// Sends the current track metadata to the Now Playing widget.
-    fn update_metadata(&self) {
+    fn update_metadata(&mut self) {
         let Current::Track(track) = &self.current else {
             return;
         };
 
-        let _ = self.update_tx.send(MacosUpdate::Metadata {
-            title: track.display.clone(),
+        let Some(controls) = self.controls.as_mut() else {
+            return;
+        };
+
+        let _ = controls.set_metadata(MediaMetadata {
+            title: Some(track.display.as_str()),
+            album: None,
+            artist: None,
+            cover_url: None,
             duration: track.duration,
         });
     }
 
     /// Sends the current playback status to the Now Playing widget.
-    fn update_playback(&self) {
+    fn update_playback(&mut self) {
+        let Some(controls) = self.controls.as_mut() else {
+            return;
+        };
+
         let status = if self.current.loading() {
             MediaPlayback::Stopped
         } else if self.sink.is_paused() {
@@ -152,7 +112,7 @@ impl Server {
             MediaPlayback::Playing { progress: None }
         };
 
-        let _ = self.update_tx.send(MacosUpdate::Playback(status));
+        let _ = controls.set_playback(status);
     }
 
     /// Handles a player message, keeping macOS media controls in sync.
@@ -173,7 +133,9 @@ impl Server {
                 self.update_playback();
             }
             Message::Quit => {
-                let _ = self.update_tx.send(MacosUpdate::Quit);
+                if let Some(controls) = self.controls.as_mut() {
+                    let _ = controls.set_playback(MediaPlayback::Stopped);
+                }
             }
             _ => {}
         }

--- a/src/ui/macos.rs
+++ b/src/ui/macos.rs
@@ -1,0 +1,183 @@
+//! Contains the code for macOS media controls via the Now Playing framework.
+
+use std::{
+    sync::{
+        mpsc::{self, SyncSender},
+        Arc,
+    },
+    time::Duration,
+};
+
+use core_foundation_sys::runloop::{kCFRunLoopDefaultMode, CFRunLoopRunInMode};
+use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
+use tokio::sync::{broadcast, mpsc as tmpsc};
+
+use crate::{player::Current, ui::Update, Message};
+
+use super::State;
+
+/// Internal update sent from the tokio runtime to the macOS media thread.
+enum MacosUpdate {
+    /// Update the Now Playing metadata with a new track title and duration.
+    Metadata {
+        /// The display name of the track.
+        title: String,
+        /// The duration of the track, if known.
+        duration: Option<Duration>,
+    },
+    /// Update the playback status (playing, paused, or stopped).
+    Playback(MediaPlayback),
+    /// Shut down the media controls thread.
+    Quit,
+}
+
+/// Handle to the macOS Now Playing / media controls background thread.
+pub struct Server {
+    /// Shared audio sink, used to read paused state.
+    sink: Arc<rodio::Player>,
+
+    /// The latest known track state.
+    current: Current,
+
+    /// Channel to send updates to the background thread.
+    update_tx: SyncSender<MacosUpdate>,
+
+    /// Broadcast receiver for track/state updates from the player.
+    receiver: broadcast::Receiver<Update>,
+}
+
+impl Server {
+    /// Creates the macOS media controls server and spawns the background thread.
+    pub fn new(
+        state: State,
+        sender: tmpsc::Sender<Message>,
+        receiver: broadcast::Receiver<Update>,
+    ) -> Self {
+        let (update_tx, update_rx) = mpsc::sync_channel::<MacosUpdate>(8);
+
+        std::thread::spawn(move || {
+            let config = PlatformConfig {
+                display_name: "lowfi",
+                dbus_name: "dev.talwat.lowfi",
+                hwnd: None,
+            };
+
+            let Ok(mut controls) = MediaControls::new(config) else {
+                return;
+            };
+
+            let _ = controls.attach(move |event: MediaControlEvent| {
+                let message = match event {
+                    MediaControlEvent::Play => Message::Play,
+                    MediaControlEvent::Pause => Message::Pause,
+                    MediaControlEvent::Toggle => Message::PlayPause,
+                    MediaControlEvent::Next => Message::Next,
+                    MediaControlEvent::Quit => Message::Quit,
+                    _ => return,
+                };
+                let _ = sender.try_send(message);
+            });
+
+            loop {
+                // Drain all pending updates from the tokio side without blocking.
+                loop {
+                    match update_rx.try_recv() {
+                        Ok(MacosUpdate::Metadata { title, duration }) => {
+                            let _ = controls.set_metadata(MediaMetadata {
+                                title: Some(title.as_str()),
+                                album: None,
+                                artist: None,
+                                cover_url: None,
+                                duration,
+                            });
+                        }
+                        Ok(MacosUpdate::Playback(status)) => {
+                            let _ = controls.set_playback(status);
+                        }
+                        Ok(MacosUpdate::Quit) | Err(mpsc::TryRecvError::Disconnected) => return,
+                        Err(mpsc::TryRecvError::Empty) => break,
+                    }
+                }
+
+                // Pump this thread's CFRunLoop briefly, in case souvlaki dispatches
+                // callbacks here rather than on the main queue.
+                unsafe {
+                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, 0);
+                }
+            }
+        });
+
+        // Pump the main CFRunLoop on a ~60 Hz interval so that MPRemoteCommandCenter
+        // callbacks (dispatched on GCD's main queue) are delivered. Tokio uses kqueue
+        // internally and never spins the Cocoa run loop itself. With current_thread
+        // flavor this task runs on the main thread, which is exactly where the main
+        // queue needs to be drained.
+        tokio::spawn(async {
+            let mut interval = tokio::time::interval(Duration::from_millis(16));
+            loop {
+                interval.tick().await;
+                unsafe {
+                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, 1);
+                }
+            }
+        });
+
+        Self {
+            sink: state.sink,
+            current: state.current,
+            update_tx,
+            receiver,
+        }
+    }
+
+    /// Sends the current track metadata to the Now Playing widget.
+    fn update_metadata(&self) {
+        let Current::Track(track) = &self.current else {
+            return;
+        };
+
+        let _ = self.update_tx.send(MacosUpdate::Metadata {
+            title: track.display.clone(),
+            duration: track.duration,
+        });
+    }
+
+    /// Sends the current playback status to the Now Playing widget.
+    fn update_playback(&self) {
+        let status = if self.current.loading() {
+            MediaPlayback::Stopped
+        } else if self.sink.is_paused() {
+            MediaPlayback::Paused { progress: None }
+        } else {
+            MediaPlayback::Playing { progress: None }
+        };
+
+        let _ = self.update_tx.send(MacosUpdate::Playback(status));
+    }
+
+    /// Handles a player message, keeping macOS media controls in sync.
+    #[allow(clippy::unused_async)]
+    pub async fn handle(&mut self, message: &Message) -> super::Result<()> {
+        while let Ok(update) = self.receiver.try_recv() {
+            if let Update::Track(current) = update {
+                self.current = current;
+            }
+        }
+
+        match message {
+            Message::Init | Message::Loaded | Message::Next => {
+                self.update_metadata();
+                self.update_playback();
+            }
+            Message::Play | Message::Pause | Message::PlayPause => {
+                self.update_playback();
+            }
+            Message::Quit => {
+                let _ = self.update_tx.send(MacosUpdate::Quit);
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Integrates macOS MPRemoteCommandCenter so playback can be controlled from the lock screen, Control Center, and media keys.

- Spawns a background thread to own MediaControls (not Send-safe)
- Pumps CFRunLoop at ~60 Hz from a tokio task so GCD main-queue callbacks (required by MPRemoteCommandCenter) are delivered
- Maps Play/Pause/Toggle/Next/Quit events to existing Message types
- Syncs track metadata and playback state on Init/Loaded/Next/Pause