### PR TITLE
Update Debian/Ubuntu install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ zypper install lowfi
 > This uses an unofficial Debian repository maintained by [Dario Griffo](https://github.com/dariogriffo).
 
 ```sh
-curl -sS https://debian.griffo.io/3B9335DF576D3D58059C6AA50B56A1A69762E9FF.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
-echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
+echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list
+sudo apt update
 sudo apt install -y lowfi
 ```
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -70,8 +70,10 @@ zypper install lowfi
 > Ce packet est sur un dépôt non officiel maintenu par [Dario Griffo](https://github.com/dariogriffo).
 
 ```sh
-curl -sS https://debian.griffo.io/3B9335DF576D3D58059C6AA50B56A1A69762E9FF.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
-echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
+echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list
+sudo apt update
 sudo apt install -y lowfi
 ```
 


### PR DESCRIPTION
The Debian repository hosting lowfi packages moved from `debian.griffo.io` to `deb.griffo.io` to comply with the [Debian trademark policy](https://www.debian.org/trademark). The old domain redirects permanently, but there's a more important fix here: the README referenced a **signing key that was rotated in March 2025**, so the current instructions fail signature verification for new users.

This updates the snippet to:
- the new domain and current signing key
- the modern `/etc/apt/keyrings` + `signed-by=` layout (key trusted only for this repo instead of globally)
- add the missing `sudo` on the `gpg` write to `/etc` and the `apt update` step before install